### PR TITLE
Change Cirq's upper bound to 0.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,6 @@ setuptools.setup(
     setup_requires=["setuptools_scm~=6.0"],
     install_requires=[
         "z-quantum-core",
-        "cirq>=0.9.1,<=0.10",
+        "cirq>=0.9.1,<=0.11",
     ],
 )


### PR DESCRIPTION
`openfermion` shows warning messages when `cirq` 0.10 is being installed. Thus, I am changing the upper bound here to make the installation go well. This doesn't break any `pip` dep resolution routines. But people would probably need to reset their envs since uninstalling the old cirq isn't sufficient due to modular modifications from Google.