### PR TITLE
ZQS-257 Adapt CirqSimulator to new QuantumSimulator interface

### DIFF
--- a/tests/qecirq/simulator/simulator_test.py
+++ b/tests/qecirq/simulator/simulator_test.py
@@ -143,19 +143,6 @@ class TestCirqSimulator(QuantumSimulatorTests):
         for (ampl1, ampl2) in zip(wavefunction1.amplitudes, wavefunction2.amplitudes):
             assert ampl1 == ampl2
 
-    def test_get_wavefunction_uses_provided_initial_state(self):
-        circuit = Circuit([H(0), H(1)])
-        initial_state = np.array([0, 1, 0, 0])
-        simulator = CirqSimulator()
-        np.testing.assert_allclose(
-            simulator.get_wavefunction(circuit, initial_state=initial_state),
-            np.array([0.5, -0.5, 0.5, -0.5])
-        )
-        np.testing.assert_allclose(
-            simulator.get_wavefunction(circuit),
-            0.5 * np.ones(4)
-        )
-
 
 class TestCirqSimulatorGates(QuantumSimulatorGatesTest):
     pass


### PR DESCRIPTION
This PR adapts CirqSimulator to changes in `QuantumSimulator` interface and thus adds support for nonnative operations.